### PR TITLE
Fixed invalid import

### DIFF
--- a/lib/activedirectory.js
+++ b/lib/activedirectory.js
@@ -1,4 +1,5 @@
 const events                            = require('events');
+const bunyan                            = require('bunyan');
 const util                              = require('util');
 const ldap                              = require('ldapjs');
 const _                                 = require('underscore');


### PR DESCRIPTION
Authehticate method failed because searched for a bunyan const that it was not imported